### PR TITLE
Fix StatHat::Reporter to allow #finish to avoid deadlocks waiting for worker threads

### DIFF
--- a/test/test_stathat.rb
+++ b/test/test_stathat.rb
@@ -66,4 +66,18 @@ class TestStathat < MiniTest::Unit::TestCase
                 assert_equal(r.msg, "invalid keys", "incorrect error message")
                 assert_equal(r.status, 500, "incorrect status code")
         end
+
+        def test_stat_on_finished_queue
+                reporter = StatHat::Reporter.instance
+                reporter.finish
+
+                assert !StatHat::API.ez_post_value("test ez count queued stat", "test@stathat.com", 12)
+        end
+
+        def test_reporter_finish
+                reporter = StatHat::Reporter.instance
+                reporter.finish
+
+                assert !reporter.running?
+        end
 end


### PR DESCRIPTION
Worker threads would previously block waiting for content to be pushed
onto the shared queue. So even though the thread that calls #finish marks the
shared @running variable as false, the worker threads will never wake up to
notice that they should quit, thus causing a deadlock when the calling thread
`#join`s the worker threads.

Avoid this situation by pushing the process control in-band with the queued
content, to signal to the worker threads that they should wake up _and_ stop
processing.

---

This is a minimal change to allow `#finish` to work as expected. What would probably be better is creating the threads on demand as the events are pushed into the API. This would eliminate the need for the queue and process control, at the expense of creating 1 thread per event. I haven't measured the impact of this style on GC or performance (eg. thread startup cost), but I suspect it would be negligible in the operation of a larger project.
