### PR TITLE
Switching to use https by default

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = stathat
 
-Description goes here.
+Ruby library for stathat
 
 == Contributing to stathat
 

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -7,9 +7,9 @@ require 'singleton'
 
 module StatHat
         class Common
-                CLASSIC_VALUE_URL = "http://api.stathat.com/v"
-                CLASSIC_COUNT_URL = "http://api.stathat.com/c"
-                EZ_URL = "http://api.stathat.com/ez"
+                CLASSIC_VALUE_URL = "https://api.stathat.com/v"
+                CLASSIC_COUNT_URL = "https://api.stathat.com/c"
+                EZ_URL = "https://api.stathat.com/ez"
 
                 class << self
                        # def send_to_stathat(url, args)

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -12,13 +12,6 @@ module StatHat
                 EZ_URL = "https://api.stathat.com/ez"
 
                 class << self
-                       # def send_to_stathat(url, args)
-                       #         uri = URI.parse(url)
-                       #         uri.query = URI.encode_www_form(args)
-                       #         resp = Net::HTTP.get(uri)
-                       #         return Response.new(resp)
-                       # end
-
                         def send_to_stathat(url, args)
                                 uri = URI.parse(url)
 


### PR DESCRIPTION
As stathat now supports https ([https://www.stathat.com/manual](https://www.stathat.com/manual) > **Can I submit data over https?**), it seems to make more sense to have the default urls as https, rather than http.
