### PR TITLE
accommodate new API behavior

### DIFF
--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -22,8 +22,8 @@ module StatHat
                                         uri.query = args.map { |arg, val| arg.to_s + "=" + CGI::escape(val.to_s) }.join('&')
                                 end
 
-                                resp = Net::HTTP.get(uri)
-                                return Response.new(resp)
+                                resp = Net::HTTP.get_response(uri)
+                                return Response.new(resp.body, resp.code.to_i)
                         end
                 end
         end
@@ -173,18 +173,23 @@ module StatHat
         end
 
         class Response
-                def initialize(body)
+                def initialize(body, http_status)
                         @body = body
+                        @http_status = http_status
                         @parsed = nil
                 end
 
                 def valid?
-                        return status == 200
+                        return (200..299).cover? status
                 end
 
                 def status
-                        parse
-                        return @parsed['status']
+                        if @body
+                                parse
+                                return @parsed['status']
+                        else
+                                return @http_status
+                        end
                 end
 
                 def msg

--- a/test/test_stathat.rb
+++ b/test/test_stathat.rb
@@ -42,15 +42,13 @@ class TestStathat < MiniTest::Unit::TestCase
         def test_ez_value_sync
                 resp = StatHat::SyncAPI.ez_post_value("test ez value stat", "test@stathat.com", 0.92)
                 assert(resp.valid?, "response was invalid")
-                assert_equal(resp.msg, "ok", "message should be 'ok'")
-                assert_equal(resp.status, 200, "status should be 200")
+                assert_equal(resp.status, 204, "status should be 200")
         end
 
         def test_ez_count_sync
                 resp = StatHat::SyncAPI.ez_post_value("test ez count stat", "test@stathat.com", 12)
                 assert(resp.valid?, "response was invalid")
-                assert_equal(resp.msg, "ok", "message should be 'ok'")
-                assert_equal(resp.status, 200, "status should be 200")
+                assert_equal(resp.status, 204, "status should be 200")
         end
 
         def test_classic_count_bad_keys_sync


### PR DESCRIPTION
As of May 2017, successful submissions to stathat do
not return a body, and the test suite (correctly) fails:

https://blog.stathat.com/2017/05/05/bandwidth.html

This changes the code and tests to accommodate this new behavior.

- the success code is now 200, not 204, so all 200s are
  considered successful
- because there is no body, we no longer check for resp.msg == "ok"
- oddly, failures return a "status: 500" in their body, but
  still have a 200 success code. I don't know if this is desired behavior or a bug,
  and I don't know how long this has been the case. i have written to StatHat support about it.
  so, we still parse for a code in the body and let it take precedent