### PR TITLE
Spool down threads when exiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,5 @@
 source "http://rubygems.org"
-# Add dependencies required to use your gem here.
-# Example:
-#   gem "activesupport", ">= 2.3.5"
 
-# Add dependencies to develop your gem here.
-# Include everything needed to run rake, tests, features, etc.
 group :development do
   gem "minitest", ">= 0"
-#  gem "bundler", "~> 1.0.0"
-#  gem "jeweler", "~> 1.5.2"
-#  gem "rcov", ">= 0"
-#  gem "rocco"
 end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -22,8 +22,8 @@ module StatHat
                                         uri.query = args.map { |arg, val| arg.to_s + "=" + CGI::escape(val.to_s) }.join('&')
                                 end
 
-                                resp = Net::HTTP.get(uri)
-                                return Response.new(resp)
+                                resp = Net::HTTP.get_response(uri)
+                                return Response.new(resp.body, resp.code.to_i)
                         end
                 end
         end
@@ -173,18 +173,23 @@ module StatHat
         end
 
         class Response
-                def initialize(body)
+                def initialize(body, http_status)
                         @body = body
+                        @http_status = http_status
                         @parsed = nil
                 end
 
                 def valid?
-                        return status == 200
+                        return (200..299).cover? status
                 end
 
                 def status
-                        parse
-                        return @parsed['status']
+                        if @body
+                                parse
+                                return @parsed['status']
+                        else
+                                return @http_status
+                        end
                 end
 
                 def msg

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -6,201 +6,202 @@ require 'thread'
 require 'singleton'
 
 module StatHat
-        class Common
-                CLASSIC_VALUE_URL = "https://api.stathat.com/v"
-                CLASSIC_COUNT_URL = "https://api.stathat.com/c"
-                EZ_URL = "https://api.stathat.com/ez"
 
-                class << self
-                        def send_to_stathat(url, args)
-                                uri = URI.parse(url)
+  class Common
+    CLASSIC_VALUE_URL = "https://api.stathat.com/v"
+    CLASSIC_COUNT_URL = "https://api.stathat.com/c"
+    EZ_URL = "https://api.stathat.com/ez"
 
-                                begin
-                                        uri.query = URI.encode_www_form(args)
-                                rescue NoMethodError => e
-                                        # backwards compatability for pre 1.9.x
-                                        uri.query = args.map { |arg, val| arg.to_s + "=" + CGI::escape(val.to_s) }.join('&')
-                                end
+    class << self
+      def send_to_stathat(url, args)
+        uri = URI.parse(url)
 
-                                resp = Net::HTTP.get_response(uri)
-                                return Response.new(resp.body, resp.code.to_i)
-                        end
-                end
+        begin
+          uri.query = URI.encode_www_form(args)
+        rescue NoMethodError => e
+          # backwards compatability for pre 1.9.x
+          uri.query = args.map { |arg, val| arg.to_s + "=" + CGI::escape(val.to_s) }.join('&')
         end
 
-        class SyncAPI
-                class << self
-                        def ez_post_value(stat_name, ezkey, value, timestamp=nil)
-                                args = { :stat => stat_name,
-                                        :ezkey => ezkey,
-                                        :value => value }
-                                args[:t] = timestamp unless timestamp.nil?
-                                Common::send_to_stathat(Common::EZ_URL, args)
-                        end
+        resp = Net::HTTP.get_response(uri)
+        return Response.new(resp.body, resp.code.to_i)
+      end
+    end
+  end
 
-                        def ez_post_count(stat_name, ezkey, count, timestamp=nil)
-                                args = { :stat => stat_name,
-                                        :ezkey => ezkey,
-                                        :count => count }
-                                args[:t] = timestamp unless timestamp.nil?
-                                Common::send_to_stathat(Common::EZ_URL, args)
-                        end
+  class SyncAPI
+    class << self
+      def ez_post_value(stat_name, ezkey, value, timestamp=nil)
+        args = { :stat => stat_name,
+          :ezkey => ezkey,
+          :value => value }
+        args[:t] = timestamp unless timestamp.nil?
+        Common::send_to_stathat(Common::EZ_URL, args)
+      end
 
-                        def post_count(stat_key, user_key, count, timestamp=nil)
-                                args = { :key => stat_key,
-                                        :ukey => user_key,
-                                        :count => count }
-                                args[:t] = timestamp unless timestamp.nil?
-                                Common::send_to_stathat(Common::CLASSIC_COUNT_URL, args)
-                        end
+      def ez_post_count(stat_name, ezkey, count, timestamp=nil)
+        args = { :stat => stat_name,
+          :ezkey => ezkey,
+          :count => count }
+        args[:t] = timestamp unless timestamp.nil?
+        Common::send_to_stathat(Common::EZ_URL, args)
+      end
 
-                        def post_value(stat_key, user_key, value, timestamp=nil)
-                                args = { :key => stat_key,
-                                        :ukey => user_key,
-                                        :value => value }
-                                args[:t] = timestamp unless timestamp.nil?
-                                Common::send_to_stathat(Common::CLASSIC_VALUE_URL, args)
-                        end
-                end
+      def post_count(stat_key, user_key, count, timestamp=nil)
+        args = { :key => stat_key,
+          :ukey => user_key,
+          :count => count }
+        args[:t] = timestamp unless timestamp.nil?
+        Common::send_to_stathat(Common::CLASSIC_COUNT_URL, args)
+      end
+
+      def post_value(stat_key, user_key, value, timestamp=nil)
+        args = { :key => stat_key,
+          :ukey => user_key,
+          :value => value }
+        args[:t] = timestamp unless timestamp.nil?
+        Common::send_to_stathat(Common::CLASSIC_VALUE_URL, args)
+      end
+    end
+  end
+
+  class API
+    class << self
+      def ez_post_value(stat_name, ezkey, value, timestamp=nil, &block)
+        Reporter.instance.ez_post_value(stat_name, ezkey, value, timestamp, block)
+      end
+
+      def ez_post_count(stat_name, ezkey, count, timestamp=nil, &block)
+        Reporter.instance.ez_post_count(stat_name, ezkey, count, timestamp, block)
+      end
+
+      def post_count(stat_key, user_key, count, timestamp=nil, &block)
+        Reporter.instance.post_count(stat_key, user_key, count, timestamp, block)
+      end
+
+      def post_value(stat_key, user_key, value, timestamp=nil, &block)
+        Reporter.instance.post_value(stat_key, user_key, value, timestamp, block)
+      end
+    end
+  end
+
+  class Reporter
+    include Singleton
+
+    def initialize
+      @que = Queue.new
+      @runlock = Mutex.new
+      run_pool()
+    end
+
+    def finish()
+      stop_pool
+      # XXX serialize queue?
+    end
+
+    def post_value(stat_key, user_key, value, timestamp, cb)
+      args = { :key => stat_key,
+        :ukey => user_key,
+        :value => value }
+      args[:t] = timestamp unless timestamp.nil?
+      enqueue(Common::CLASSIC_VALUE_URL, args, cb)
+    end
+
+    def post_count(stat_key, user_key, count, timestamp, cb)
+      args = { :key => stat_key,
+        :ukey => user_key,
+        :count => count }
+      args[:t] = timestamp unless timestamp.nil?
+      enqueue(Common::CLASSIC_COUNT_URL, args, cb)
+    end
+
+    def ez_post_value(stat_name, ezkey, value, timestamp, cb)
+      args = { :stat => stat_name,
+        :ezkey => ezkey,
+        :value => value }
+      args[:t] = timestamp unless timestamp.nil?
+      enqueue(Common::EZ_URL, args, cb)
+    end
+
+    def ez_post_count(stat_name, ezkey, count, timestamp, cb)
+      args = { :stat => stat_name,
+        :ezkey => ezkey,
+        :count => count }
+      args[:t] = timestamp unless timestamp.nil?
+      enqueue(Common::EZ_URL, args, cb)
+    end
+
+    private
+    def run_pool
+      @runlock.synchronize { @running = true }
+      @pool = []
+      5.times do |i|
+        @pool[i] = Thread.new do
+          while true do
+            point = @que.pop
+            # XXX check for error?
+            begin
+              resp = Common::send_to_stathat(point[:url], point[:args])
+              if point[:cb]
+                point[:cb].call(resp)
+              end
+            rescue
+              pp $!
+            end
+            @runlock.synchronize {
+              break unless @running
+            }
+          end
         end
+      end
+    end
 
-        class API
-                class << self
-                        def ez_post_value(stat_name, ezkey, value, timestamp=nil, &block)
-                                Reporter.instance.ez_post_value(stat_name, ezkey, value, timestamp, block)
-                        end
+    def stop_pool()
+      @runlock.synchronize {
+        @running = false
+      }
+      @pool.each do |th|
+        th.join if th && th.alive?
+      end
+    end
 
-                        def ez_post_count(stat_name, ezkey, count, timestamp=nil, &block)
-                                Reporter.instance.ez_post_count(stat_name, ezkey, count, timestamp, block)
-                        end
+    def enqueue(url, args, cb=nil)
+      return false unless @running
+      point = {:url => url, :args => args, :cb => cb}
+      @que << point
+      true
+    end
+  end
 
-                        def post_count(stat_key, user_key, count, timestamp=nil, &block)
-                                Reporter.instance.post_count(stat_key, user_key, count, timestamp, block)
-                        end
+  class Response
+    def initialize(body, http_status)
+      @body = body
+      @http_status = http_status
+      @parsed = nil
+    end
 
-                        def post_value(stat_key, user_key, value, timestamp=nil, &block)
-                                Reporter.instance.post_value(stat_key, user_key, value, timestamp, block)
-                        end
-                end
-        end
+    def valid?
+      return (200..299).cover? status
+    end
 
-        class Reporter
-                include Singleton
+    def status
+      if @body
+        parse
+        return @parsed['status']
+      else
+        return @http_status
+      end
+    end
 
-                def initialize
-                        @que = Queue.new
-                        @runlock = Mutex.new
-                        run_pool()
-                end
+    def msg
+      parse
+      return @parsed['msg']
+    end
 
-                def finish()
-                        stop_pool
-                        # XXX serialize queue?
-                end
-
-                def post_value(stat_key, user_key, value, timestamp, cb)
-                        args = { :key => stat_key,
-                                :ukey => user_key,
-                                :value => value }
-                        args[:t] = timestamp unless timestamp.nil?
-                        enqueue(Common::CLASSIC_VALUE_URL, args, cb)
-                end
-
-                def post_count(stat_key, user_key, count, timestamp, cb)
-                        args = { :key => stat_key,
-                                :ukey => user_key,
-                                :count => count }
-                        args[:t] = timestamp unless timestamp.nil?
-                        enqueue(Common::CLASSIC_COUNT_URL, args, cb)
-                end
-
-                def ez_post_value(stat_name, ezkey, value, timestamp, cb)
-                        args = { :stat => stat_name,
-                                :ezkey => ezkey,
-                                :value => value }
-                        args[:t] = timestamp unless timestamp.nil?
-                        enqueue(Common::EZ_URL, args, cb)
-                end
-
-                def ez_post_count(stat_name, ezkey, count, timestamp, cb)
-                        args = { :stat => stat_name,
-                                :ezkey => ezkey,
-                                :count => count }
-                        args[:t] = timestamp unless timestamp.nil?
-                        enqueue(Common::EZ_URL, args, cb)
-                end
-
-                private
-                def run_pool
-                        @runlock.synchronize { @running = true }
-                        @pool = []
-                        5.times do |i|
-                                @pool[i] = Thread.new do
-                                        while true do
-                                                point = @que.pop
-                                                # XXX check for error?
-                                                begin
-                                                        resp = Common::send_to_stathat(point[:url], point[:args])
-                                                        if point[:cb]
-                                                                point[:cb].call(resp)
-                                                        end
-                                                rescue
-                                                        pp $!
-                                                end
-                                                @runlock.synchronize {
-                                                        break unless @running
-                                                }
-                                        end
-                                end
-                        end
-                end
-
-                def stop_pool()
-                        @runlock.synchronize {
-                                @running = false
-                        }
-                        @pool.each do |th|
-                                th.join if th && th.alive?
-                        end
-                end
-
-                def enqueue(url, args, cb=nil)
-                        return false unless @running
-                        point = {:url => url, :args => args, :cb => cb}
-                        @que << point
-                        true
-                end
-        end
-
-        class Response
-                def initialize(body, http_status)
-                        @body = body
-                        @http_status = http_status
-                        @parsed = nil
-                end
-
-                def valid?
-                        return (200..299).cover? status
-                end
-
-                def status
-                        if @body
-                                parse
-                                return @parsed['status']
-                        else
-                                return @http_status
-                        end
-                end
-
-                def msg
-                        parse
-                        return @parsed['msg']
-                end
-
-                private
-                def parse
-                        return unless @parsed.nil?
-                        @parsed = JSON.parse(@body)
-                end
-        end
+    private
+    def parse
+      return unless @parsed.nil?
+      @parsed = JSON.parse(@body)
+    end
+  end
 end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -25,33 +25,25 @@ module StatHat
   class SyncAPI
     class << self
       def ez_post_value(stat_name, ezkey, value, timestamp=nil)
-        args = { :stat => stat_name,
-          :ezkey => ezkey,
-          :value => value }
+        args = { stat: stat_name, ezkey: ezkey, value: value }
         args[:t] = timestamp unless timestamp.nil?
         Common::send_to_stathat(Common::EZ_URL, args)
       end
 
       def ez_post_count(stat_name, ezkey, count, timestamp=nil)
-        args = { :stat => stat_name,
-          :ezkey => ezkey,
-          :count => count }
+        args = { stat: stat_name, ezkey: ezkey, count: count }
         args[:t] = timestamp unless timestamp.nil?
         Common::send_to_stathat(Common::EZ_URL, args)
       end
 
       def post_count(stat_key, user_key, count, timestamp=nil)
-        args = { :key => stat_key,
-          :ukey => user_key,
-          :count => count }
+        args = { key: stat_key, ukey: user_key, count: count }
         args[:t] = timestamp unless timestamp.nil?
         Common::send_to_stathat(Common::CLASSIC_COUNT_URL, args)
       end
 
       def post_value(stat_key, user_key, value, timestamp=nil)
-        args = { :key => stat_key,
-          :ukey => user_key,
-          :value => value }
+        args = { key: stat_key, ukey: user_key, value: value }
         args[:t] = timestamp unless timestamp.nil?
         Common::send_to_stathat(Common::CLASSIC_VALUE_URL, args)
       end
@@ -93,33 +85,25 @@ module StatHat
     end
 
     def post_value(stat_key, user_key, value, timestamp, cb)
-      args = { :key => stat_key,
-        :ukey => user_key,
-        :value => value }
+      args = { key: stat_key, ukey: user_key, value: value }
       args[:t] = timestamp unless timestamp.nil?
       enqueue(Common::CLASSIC_VALUE_URL, args, cb)
     end
 
     def post_count(stat_key, user_key, count, timestamp, cb)
-      args = { :key => stat_key,
-        :ukey => user_key,
-        :count => count }
+      args = { key: stat_key, ukey: user_key, count: count }
       args[:t] = timestamp unless timestamp.nil?
       enqueue(Common::CLASSIC_COUNT_URL, args, cb)
     end
 
     def ez_post_value(stat_name, ezkey, value, timestamp, cb)
-      args = { :stat => stat_name,
-        :ezkey => ezkey,
-        :value => value }
+      args = { stat: stat_name, ezkey: ezkey, value: value }
       args[:t] = timestamp unless timestamp.nil?
       enqueue(Common::EZ_URL, args, cb)
     end
 
     def ez_post_count(stat_name, ezkey, count, timestamp, cb)
-      args = { :stat => stat_name,
-        :ezkey => ezkey,
-        :count => count }
+      args = { stat: stat_name, ezkey: ezkey, count: count }
       args[:t] = timestamp unless timestamp.nil?
       enqueue(Common::EZ_URL, args, cb)
     end
@@ -161,7 +145,7 @@ module StatHat
 
     def enqueue(url, args, cb=nil)
       return false unless @running
-      point = {:url => url, :args => args, :cb => cb}
+      point = { url: url, args: args, cb: cb }
       @que << point
       true
     end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -132,8 +132,10 @@ module StatHat
       @que.close
 
       @pool.each do |th|
-        th.join
+        th.join(5)
       end
+
+      puts "WARNING: The StatHat queue was shut down with #{@queue.size} unprocessed tasks" unless 0 == @que.size
     end
 
     def enqueue(url, args, cb=nil)
@@ -176,4 +178,11 @@ module StatHat
       @parsed = JSON.parse(@body)
     end
   end
+end
+
+old_handler = trap("EXIT") do
+  puts "StatHat::Reporter.instance.finish in response to EXIT"
+  StatHat::Reporter.instance.finish
+
+  old_handler.call if old_handler.respond_to?(:call)
 end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -15,14 +15,7 @@ module StatHat
     class << self
       def send_to_stathat(url, args)
         uri = URI.parse(url)
-
-        begin
-          uri.query = URI.encode_www_form(args)
-        rescue NoMethodError => e
-          # backwards compatability for pre 1.9.x
-          uri.query = args.map { |arg, val| arg.to_s + "=" + CGI::escape(val.to_s) }.join('&')
-        end
-
+        uri.query = URI.encode_www_form(args)
         resp = Net::HTTP.get_response(uri)
         return Response.new(resp.body, resp.code.to_i)
       end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -76,10 +76,10 @@ module StatHat
     def initialize
       @que = Queue.new
       @runlock = Mutex.new
-      run_pool()
+      run_pool
     end
 
-    def finish()
+    def finish
       stop_pool
       # XXX serialize queue?
     end
@@ -134,7 +134,7 @@ module StatHat
       end
     end
 
-    def stop_pool()
+    def stop_pool
       @runlock.synchronize {
         @running = false
       }

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -124,7 +124,8 @@ module StatHat
       enqueue(Common::EZ_URL, args, cb)
     end
 
-    private
+  private
+
     def run_pool
       @runlock.synchronize { @running = true }
       @pool = []
@@ -191,7 +192,8 @@ module StatHat
       @parsed['msg']
     end
 
-    private
+  private
+
     def parse
       return unless @parsed.nil?
       @parsed = JSON.parse(@body)

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -75,7 +75,6 @@ module StatHat
 
     def initialize
       @que = Queue.new
-      @runlock = Mutex.new
       run_pool
     end
 
@@ -111,12 +110,10 @@ module StatHat
   private
 
     def run_pool
-      @runlock.synchronize { @running = true }
       @pool = []
       5.times do |i|
         @pool[i] = Thread.new do
-          while true do
-            point = @que.pop
+          while point = @que.pop do
             # XXX check for error?
             begin
               resp = Common::send_to_stathat(point[:url], point[:args])
@@ -126,23 +123,21 @@ module StatHat
             rescue
               pp $!
             end
-            @runlock.synchronize do
-              break unless @running
-            end
           end
         end
       end
     end
 
     def stop_pool
-      @runlock.synchronize { @running = false }
+      @que.close
+
       @pool.each do |th|
-        th.join if th && th.alive?
+        th.join
       end
     end
 
     def enqueue(url, args, cb=nil)
-      return false unless @running
+      return false if @que.closed?
       point = { url: url, args: args, cb: cb }
       @que << point
       true

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -126,18 +126,16 @@ module StatHat
             rescue
               pp $!
             end
-            @runlock.synchronize {
+            @runlock.synchronize do
               break unless @running
-            }
+            end
           end
         end
       end
     end
 
     def stop_pool
-      @runlock.synchronize {
-        @running = false
-      }
+      @runlock.synchronize { @running = false }
       @pool.each do |th|
         th.join if th && th.alive?
       end

--- a/lib/stathat.rb
+++ b/lib/stathat.rb
@@ -17,7 +17,7 @@ module StatHat
         uri = URI.parse(url)
         uri.query = URI.encode_www_form(args)
         resp = Net::HTTP.get_response(uri)
-        return Response.new(resp.body, resp.code.to_i)
+        Response.new(resp.body, resp.code.to_i)
       end
     end
   end
@@ -174,21 +174,21 @@ module StatHat
     end
 
     def valid?
-      return (200..299).cover? status
+      (200..299).cover? status
     end
 
     def status
       if @body
         parse
-        return @parsed['status']
+        @parsed['status']
       else
-        return @http_status
+        @http_status
       end
     end
 
     def msg
       parse
-      return @parsed['msg']
+      @parsed['msg']
     end
 
     private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,4 @@
 require 'rubygems'
-#require 'bundler'
-#begin
-#  Bundler.setup(:default, :development)
-#rescue Bundler::BundlerError => e
-#  $stderr.puts e.message
-#  $stderr.puts "Run `bundle install` to install missing gems"
-#  exit e.status_code
-#end
 require 'minitest/unit'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/test_stathat.rb
+++ b/test/test_stathat.rb
@@ -3,65 +3,65 @@ require 'helper'
 
 class TestStathat < MiniTest::Unit::TestCase
 
-        def test_ez_value
-                StatHat::API.ez_post_value("test ez value stat", "test@stathat.com", 0.92) do |resp|
-                        assert(resp.valid?, "response was invalid")
-                        assert_equal(resp.msg, "ok", "message should be 'ok'")
-                        assert_equal(resp.status, 200, "status should be 200")
-                end
-                sleep(1)
-        end
+  def test_ez_value
+    StatHat::API.ez_post_value("test ez value stat", "test@stathat.com", 0.92) do |resp|
+      assert(resp.valid?, "response was invalid")
+      assert_equal(resp.msg, "ok", "message should be 'ok'")
+      assert_equal(resp.status, 200, "status should be 200")
+    end
+    sleep(1)
+  end
 
-        def test_ez_count
-                StatHat::API.ez_post_value("test ez count stat", "test@stathat.com", 12) do |r|
-                        assert(r.valid?, "response was invalid")
-                        assert_equal(r.msg, "ok", "message should be 'ok'")
-                        assert_equal(r.status, 200, "status should be 200")
-                end
-                sleep(1)
-        end
+  def test_ez_count
+    StatHat::API.ez_post_value("test ez count stat", "test@stathat.com", 12) do |r|
+      assert(r.valid?, "response was invalid")
+      assert_equal(r.msg, "ok", "message should be 'ok'")
+      assert_equal(r.status, 200, "status should be 200")
+    end
+    sleep(1)
+  end
 
-        def test_classic_count_bad_keys
-                StatHat::API.post_count("XXXXXXXX", "YYYYYYYY", 12) do |r|
-                        assert_equal(r.valid?, false, "response was valid")
-                        assert_equal(r.msg, "invalid keys", "incorrect error message")
-                        assert_equal(r.status, 500, "incorrect status code")
-                end
-                sleep(1)
-        end
+  def test_classic_count_bad_keys
+    StatHat::API.post_count("XXXXXXXX", "YYYYYYYY", 12) do |r|
+      assert_equal(r.valid?, false, "response was valid")
+      assert_equal(r.msg, "invalid keys", "incorrect error message")
+      assert_equal(r.status, 500, "incorrect status code")
+    end
+    sleep(1)
+  end
 
-        def test_classic_value_bad_keys
-                StatHat::API.post_value("ZZZZZZZZ", "YYYYYYYYY", 0.92) do |r|
-                        assert_equal(r.valid?, false, "response was valid")
-                        assert_equal(r.msg, "invalid keys", "incorrect error message")
-                        assert_equal(r.status, 500, "incorrect status code")
-                end
-                sleep(1)
-        end
+  def test_classic_value_bad_keys
+    StatHat::API.post_value("ZZZZZZZZ", "YYYYYYYYY", 0.92) do |r|
+      assert_equal(r.valid?, false, "response was valid")
+      assert_equal(r.msg, "invalid keys", "incorrect error message")
+      assert_equal(r.status, 500, "incorrect status code")
+    end
+    sleep(1)
+  end
 
-        def test_ez_value_sync
-                resp = StatHat::SyncAPI.ez_post_value("test ez value stat", "test@stathat.com", 0.92)
-                assert(resp.valid?, "response was invalid")
-                assert_equal(resp.status, 204, "status should be 200")
-        end
+  def test_ez_value_sync
+    resp = StatHat::SyncAPI.ez_post_value("test ez value stat", "test@stathat.com", 0.92)
+    assert(resp.valid?, "response was invalid")
+    assert_equal(resp.status, 204, "status should be 200")
+  end
 
-        def test_ez_count_sync
-                resp = StatHat::SyncAPI.ez_post_value("test ez count stat", "test@stathat.com", 12)
-                assert(resp.valid?, "response was invalid")
-                assert_equal(resp.status, 204, "status should be 200")
-        end
+  def test_ez_count_sync
+    resp = StatHat::SyncAPI.ez_post_value("test ez count stat", "test@stathat.com", 12)
+    assert(resp.valid?, "response was invalid")
+    assert_equal(resp.status, 204, "status should be 200")
+  end
 
-        def test_classic_count_bad_keys_sync
-                r = StatHat::SyncAPI.post_count("XXXXXXXX", "YYYYYYYY", 12)
-                assert_equal(r.valid?, false, "response was valid")
-                assert_equal(r.msg, "invalid keys", "incorrect error message")
-                assert_equal(r.status, 500, "incorrect status code")
-        end
+  def test_classic_count_bad_keys_sync
+    r = StatHat::SyncAPI.post_count("XXXXXXXX", "YYYYYYYY", 12)
+    assert_equal(r.valid?, false, "response was valid")
+    assert_equal(r.msg, "invalid keys", "incorrect error message")
+    assert_equal(r.status, 500, "incorrect status code")
+  end
 
-        def test_classic_value_bad_keys_sync
-                r = StatHat::SyncAPI.post_value("ZZZZZZZZ", "YYYYYYYYY", 0.92)
-                assert_equal(r.valid?, false, "response was valid")
-                assert_equal(r.msg, "invalid keys", "incorrect error message")
-                assert_equal(r.status, 500, "incorrect status code")
-        end
+  def test_classic_value_bad_keys_sync
+    r = StatHat::SyncAPI.post_value("ZZZZZZZZ", "YYYYYYYYY", 0.92)
+    assert_equal(r.valid?, false, "response was valid")
+    assert_equal(r.msg, "invalid keys", "incorrect error message")
+    assert_equal(r.status, 500, "incorrect status code")
+  end
 end

--- a/test/test_stathat.rb
+++ b/test/test_stathat.rb
@@ -42,15 +42,13 @@ class TestStathat < MiniTest::Unit::TestCase
         def test_ez_value_sync
                 resp = StatHat::SyncAPI.ez_post_value("test ez value stat", "test@stathat.com", 0.92)
                 assert(resp.valid?, "response was invalid")
-                assert_equal(resp.msg, "ok", "message should be 'ok'")
-                assert_equal(resp.status, 200, "status should be 200")
+                assert_equal(resp.status, 204, "status should be 200")
         end
 
         def test_ez_count_sync
                 resp = StatHat::SyncAPI.ez_post_value("test ez count stat", "test@stathat.com", 12)
                 assert(resp.valid?, "response was invalid")
-                assert_equal(resp.msg, "ok", "message should be 'ok'")
-                assert_equal(resp.status, 200, "status should be 200")
+                assert_equal(resp.status, 204, "status should be 200")
         end
 
         def test_classic_count_bad_keys_sync


### PR DESCRIPTION
*note: this is based on https://github.com/patrickxb/stathat/pull/9, so that should be merged first. Then this can be rebased and look tidier.*

----

This PR achieves two things.

1. it introduces a more reliable and simple way to coordinate between threads and shut them down
1. it defines behavior for TERM and INT signals - namely, it shuts down the thread pool, allowing them to finish their work first

So, it solves the problem described here: http://www.stathat.com/manual/code/ruby

>  the default StatHat::API Ruby methods are asynchronous. If you are using this gem in a script that is short-lived, you can use StatHat::SyncAPI to make synchronous calls to StatHat.

and clarified to me in a support ticket...

> It’s possible the asynchronous requests didn’t finish [before the script exited].

It's also good behavior to have in the general case such as in a web server, which might also lose some items in the queue

n.b. [each thread is given 5 seconds to shut down](https://github.com/patrickxb/stathat/pull/10/commits/8da65b06ce767357622c98e463cfecbcd66c3786#diff-7ddcdca3d13a1dbf747d45aec0b53f0e52a1ae640ff5a903824b0f97ba17313dR135), serially (as opposed to the previous infinite time). If we want to give all threads 5 (or whatever) seconds to shut down from the start of stop_pool to guarantee that the overall time is fixed, we can use an approach like [this](https://github.com/jmettraux/rufus-scheduler/blob/64591be6a2c80149839861389a0ed8708e279198/lib/rufus/scheduler.rb#L555).

let me know what you think!


